### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/infinispan/parent/pom.xml
+++ b/infinispan/parent/pom.xml
@@ -122,7 +122,7 @@
       <version.com.intellij.forms_rt>6.0.5</version.com.intellij.forms_rt>
       <version.commons.compress>1.4</version.commons.compress>
       <version.commons.codec>1.4</version.commons.codec>
-      <version.commons.collections>3.2.1</version.commons.collections>
+      <version.commons.collections>3.2.2</version.commons.collections>
       <version.commons.dbcp>1.4</version.commons.dbcp>
       <version.commons.pool>1.6</version.commons.pool>
       <version.commons.httpclient>3.1</version.commons.httpclient>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
